### PR TITLE
Don't track data.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+data.txt

--- a/data.txt
+++ b/data.txt
@@ -1,1 +1,0 @@
-Here are the top 21 Asdfa profiles on LinkedIn. Get all the articles, experts, jobs, and insights you need.

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
 echo "cloning crouton clipboard!"
 git clone http://github.com/zwhitchcox/crouton-clipboard ~/.crouton-clipboard
+touch ~/.crouton-clipboard/data.txt
 echo "adding startup script to .bashrc"
 echo "(nohup node ~/.crouton-clipboard/server.js > /dev/null 2>&1 &)                                                                          " >> $HOME/.bashrc
 echo "adding copy/paste commands to vimrc"


### PR DESCRIPTION
Git currently tracks the clipboard file, which it probably shouldn't do. This change creates the file, if it doesn't exist, on installation.